### PR TITLE
Feat(#8): 랭킹 테이블 생성 및 로직 구현

### DIFF
--- a/src/main/java/com/example/mixmix/auth/application/AuthMemberService.java
+++ b/src/main/java/com/example/mixmix/auth/application/AuthMemberService.java
@@ -9,6 +9,8 @@ import com.example.mixmix.member.domain.Member;
 import com.example.mixmix.member.domain.SocialType;
 import com.example.mixmix.member.domain.repository.MemberRepository;
 import java.util.Optional;
+
+import com.example.mixmix.ranking.application.RankingService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthMemberService {
 
     private final MemberRepository memberRepository;
+    private final RankingService rankingService;
 
     @Transactional
     public MemberLoginResDto saveUserInfo(UserInfo userInfo, SocialType provider) {
@@ -55,6 +58,7 @@ public class AuthMemberService {
                 .introduction("")
                 .build();
 
+        rankingService.createRanking(member);
         return memberRepository.save(member);
     }
 

--- a/src/main/java/com/example/mixmix/member/domain/Member.java
+++ b/src/main/java/com/example/mixmix/member/domain/Member.java
@@ -2,6 +2,7 @@ package com.example.mixmix.member.domain;
 
 import com.example.mixmix.global.entity.BaseEntity;
 import com.example.mixmix.global.entity.Status;
+import com.example.mixmix.ranking.domain.Ranking;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -42,6 +43,9 @@ public class Member extends BaseEntity {
     private Integer streak = 0;
 
     private LocalDateTime lastStreakUpdate;
+
+    @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Ranking ranking;
 
     @Enumerated(value = EnumType.STRING)
     private SolvedStatus hasSolved;

--- a/src/main/java/com/example/mixmix/ranking/api/RankingController.java
+++ b/src/main/java/com/example/mixmix/ranking/api/RankingController.java
@@ -1,0 +1,53 @@
+package com.example.mixmix.ranking.api;
+
+import com.example.mixmix.global.template.RspTemplate;
+import com.example.mixmix.ranking.api.dto.response.RankingInfoResDto;
+import com.example.mixmix.ranking.api.dto.response.RankingListResDto;
+import com.example.mixmix.ranking.application.RankingService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/rankings")
+public class RankingController {
+
+    private final RankingService rankingService;
+
+    @Operation(summary = "상위 10위 랭킹 조회", description = "Streak 랭킹 상위 10위의 목록을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Streak 랭킹 상위 10위 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @GetMapping
+    public RspTemplate<RankingListResDto> rankList() {
+        return new RspTemplate<>(HttpStatus.OK, "Streak 랭킹 상위 10위 조회 성공",
+                rankingService.getRankingList());
+    }
+
+    @Operation(summary = "회원별 랭킹 조회", description = "해당 id를 가진 회원의 랭킹을 조회합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "해당 회원의 랭킹 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @GetMapping("/{memberId}")
+    public RspTemplate<RankingInfoResDto> memberRanking(@PathVariable("memberId") Long memberId) {
+        return new RspTemplate<>(HttpStatus.OK, "해당 회원의 랭킹 조회 성공",
+                rankingService.getRanking(memberId));
+    }
+
+}

--- a/src/main/java/com/example/mixmix/ranking/api/dto/response/RankingInfoResDto.java
+++ b/src/main/java/com/example/mixmix/ranking/api/dto/response/RankingInfoResDto.java
@@ -1,0 +1,15 @@
+package com.example.mixmix.ranking.api.dto.response;
+
+import com.example.mixmix.ranking.domain.Ranking;
+
+public record RankingInfoResDto(
+        String email,
+        Integer streakRank
+) {
+    public static RankingInfoResDto from(Ranking ranking) {
+        return new RankingInfoResDto(
+                ranking.getMember().getEmail(),
+                ranking.getStreakRank()
+        );
+    }
+}

--- a/src/main/java/com/example/mixmix/ranking/api/dto/response/RankingListResDto.java
+++ b/src/main/java/com/example/mixmix/ranking/api/dto/response/RankingListResDto.java
@@ -1,0 +1,15 @@
+package com.example.mixmix.ranking.api.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record RankingListResDto(
+        List<RankingInfoResDto> rankingInfoResDto
+) {
+    public static RankingListResDto of(List<RankingInfoResDto> rankingInfoResDtoList) {
+        return RankingListResDto.builder()
+                .rankingInfoResDto(rankingInfoResDtoList).build();
+    }
+}

--- a/src/main/java/com/example/mixmix/ranking/application/RankingService.java
+++ b/src/main/java/com/example/mixmix/ranking/application/RankingService.java
@@ -1,0 +1,63 @@
+package com.example.mixmix.ranking.application;
+
+import com.example.mixmix.global.entity.Status;
+import com.example.mixmix.member.domain.Member;
+import com.example.mixmix.member.domain.repository.MemberRepository;
+import com.example.mixmix.member.exception.MemberNotFoundException;
+import com.example.mixmix.ranking.api.dto.response.RankingInfoResDto;
+import com.example.mixmix.ranking.api.dto.response.RankingListResDto;
+import com.example.mixmix.ranking.domain.Ranking;
+import com.example.mixmix.ranking.domain.repository.RankingRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class RankingService {
+
+    private final RankingRepository rankingRepository;
+    private final MemberRepository memberRepository;
+
+    public RankingListResDto getRankingList() {
+        List<RankingInfoResDto> rankingTop10List = rankingRepository.findTop10ByOrderByStreakRankDesc()
+                .stream()
+                .map(RankingInfoResDto::from)
+                .toList();
+
+        return RankingListResDto.of(rankingTop10List);
+    }
+
+    public RankingInfoResDto getRanking(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        Ranking ranking = rankingRepository.findByMember(member);
+        return RankingInfoResDto.from(ranking);
+    }
+
+    public void createRanking(Member member) {
+        Ranking ranking = Ranking.builder()
+                .member(member)
+                .streakRank(null)
+                .status(Status.ACTIVE)
+                .build();
+
+        rankingRepository.save(ranking);
+    }
+
+    @Scheduled(fixedRate = 300000)
+    public void updateRankings() {
+        List<Ranking> sortedRankingList = rankingRepository.findAllRankingOrdered();
+
+        Integer rank = 1;
+        for (Ranking ranking : sortedRankingList) {
+            ranking.updateRank(rank);
+        }
+
+        rankingRepository.saveAll(sortedRankingList);
+    }
+}

--- a/src/main/java/com/example/mixmix/ranking/domain/Ranking.java
+++ b/src/main/java/com/example/mixmix/ranking/domain/Ranking.java
@@ -1,0 +1,35 @@
+package com.example.mixmix.ranking.domain;
+
+import com.example.mixmix.global.entity.BaseEntity;
+import com.example.mixmix.global.entity.Status;
+import com.example.mixmix.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Ranking extends BaseEntity {
+
+    @Enumerated(EnumType.STRING)
+    private Status status;
+
+    private Integer streakRank;
+
+    @OneToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @Builder
+    public Ranking(Status status, Integer streakRank, Member member) {
+        this.status = status;
+        this.streakRank = streakRank;
+        this.member = member;
+    }
+
+    public void updateRank(Integer newRank) {
+        this.streakRank = newRank;
+    }
+}

--- a/src/main/java/com/example/mixmix/ranking/domain/repository/RankingCustomRepository.java
+++ b/src/main/java/com/example/mixmix/ranking/domain/repository/RankingCustomRepository.java
@@ -1,0 +1,9 @@
+package com.example.mixmix.ranking.domain.repository;
+
+import com.example.mixmix.ranking.domain.Ranking;
+
+import java.util.List;
+
+public interface RankingCustomRepository {
+    List<Ranking> findAllRankingOrdered();
+}

--- a/src/main/java/com/example/mixmix/ranking/domain/repository/RankingCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mixmix/ranking/domain/repository/RankingCustomRepositoryImpl.java
@@ -1,0 +1,35 @@
+package com.example.mixmix.ranking.domain.repository;
+
+import com.example.mixmix.global.entity.Status;
+import com.example.mixmix.member.domain.QMember;
+import com.example.mixmix.ranking.domain.QRanking;
+import com.example.mixmix.ranking.domain.Ranking;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RankingCustomRepositoryImpl implements RankingCustomRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Ranking> findAllRankingOrdered() {
+        QRanking ranking = QRanking.ranking;
+        QMember member = QMember.member;
+
+        return queryFactory.selectFrom(ranking)
+                .join(ranking.member, member)
+                .fetchJoin()
+                .where(member.status.eq(Status.ACTIVE))
+                .orderBy(
+                        member.streak.desc(),
+                        member.lastStreakUpdate.asc()
+                )
+                .fetch();
+    }
+}
+

--- a/src/main/java/com/example/mixmix/ranking/domain/repository/RankingRepository.java
+++ b/src/main/java/com/example/mixmix/ranking/domain/repository/RankingRepository.java
@@ -1,0 +1,15 @@
+package com.example.mixmix.ranking.domain.repository;
+
+import com.example.mixmix.member.domain.Member;
+import com.example.mixmix.ranking.domain.Ranking;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface RankingRepository extends JpaRepository<Ranking, Long>, RankingCustomRepository {
+
+    Ranking findByMember(Member member);
+
+    List<Ranking> findTop10ByOrderByStreakRankDesc();
+}


### PR DESCRIPTION
## 🚀 About
> feat #8 

## ✅ Key Changes

- AuthMemberService : 멤버 추가될 때 Ranking 테이블 생성되는 로직 추가
- Member : Ranking 테이블과 연관관계 추가
- 랭킹 엔티티 생성
- 랭킹 5분마다 업데이트 되는 로직 추가
- 랭킹 관련 컨트롤러, 서비스 구현
