### PR TITLE
Feat(#14): 댓글, Streak 알림 기능 구현

### DIFF
--- a/src/main/java/com/example/mixmix/member/domain/repository/MemberRepository.java
+++ b/src/main/java/com/example/mixmix/member/domain/repository/MemberRepository.java
@@ -3,6 +3,7 @@ package com.example.mixmix.member.domain.repository;
 import com.example.mixmix.member.domain.Member;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
@@ -20,4 +21,5 @@ public interface MemberRepository extends
     @Query("UPDATE Member m SET m.isStreakUpdated = false WHERE m.lastStreakUpdate < :yesterday")
     void resetStreakUpdated(LocalDateTime yesterday);
 
+    List<Member> findAllByIsStreakUpdatedFalse();
 }

--- a/src/main/java/com/example/mixmix/member/mypage/api/dto/response/MyPageInfoResDto.java
+++ b/src/main/java/com/example/mixmix/member/mypage/api/dto/response/MyPageInfoResDto.java
@@ -17,10 +17,10 @@ public record MyPageInfoResDto(
         long educationCount,
         long socialCount,
         LocalDateTime lastStreakUpdate,
-        boolean isStreakUpdated
-
+        boolean isStreakUpdated,
+        boolean unreadNotifiication
 ) {
-    public static MyPageInfoResDto from(Member member, long educationCount, long socialCount) {
+    public static MyPageInfoResDto from(Member member, long educationCount, long socialCount, boolean unreadNotifiication) {
         return MyPageInfoResDto.builder()
                 .introduction(member.getIntroduction())
                 .nationality(member.getNationality())
@@ -34,6 +34,7 @@ public record MyPageInfoResDto(
                 .socialCount(socialCount)
                 .lastStreakUpdate(member.getLastStreakUpdate())
                 .isStreakUpdated(member.isStreakUpdated())
+                .unreadNotifiication(unreadNotifiication)
                 .build();
     }
 }

--- a/src/main/java/com/example/mixmix/member/mypage/application/MyPageService.java
+++ b/src/main/java/com/example/mixmix/member/mypage/application/MyPageService.java
@@ -5,6 +5,7 @@ import com.example.mixmix.member.domain.Member;
 import com.example.mixmix.member.domain.repository.MemberRepository;
 import com.example.mixmix.member.exception.MemberNotFoundException;
 import com.example.mixmix.member.mypage.api.dto.response.MyPageInfoResDto;
+import com.example.mixmix.notification.application.NotificationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,18 +18,18 @@ public class MyPageService {
     private final MemberRepository memberRepository;
     private final FeedRepository feedRepository;
 
-    public MyPageInfoResDto findMyProfileByEmail(String email) {
+    public MyPageInfoResDto findMyProfileByEmail(String email, Boolean unreadNotification) {
         Member member = memberRepository.findByEmail(email).orElseThrow(MemberNotFoundException::new);
         long educationCount = feedRepository.countEducationFeedsByMemberId(member.getId());
         long socialCount = feedRepository.countSocialFeedsByMemberId(member.getId());
 
-        return MyPageInfoResDto.from(member, educationCount, socialCount);
+        return MyPageInfoResDto.from(member, educationCount, socialCount, unreadNotification);
     }
 
-    public MyPageInfoResDto findMyProfileById(Long memberId) {
+    public MyPageInfoResDto findMyProfileById(Long memberId, Boolean unreadNotification) {
         Member member = memberRepository.findById(memberId).orElseThrow(MemberNotFoundException::new);
         long educationCount = feedRepository.countEducationFeedsByMemberId(member.getId());
         long socialCount = feedRepository.countSocialFeedsByMemberId(member.getId());
-        return MyPageInfoResDto.from(member, educationCount, socialCount);
+        return MyPageInfoResDto.from(member, educationCount, socialCount, unreadNotification);
     }
 }

--- a/src/main/java/com/example/mixmix/notification/api/dto/NotificationController.java
+++ b/src/main/java/com/example/mixmix/notification/api/dto/NotificationController.java
@@ -1,0 +1,84 @@
+package com.example.mixmix.notification.api.dto;
+
+import com.example.mixmix.global.annotation.CurrentUserEmail;
+import com.example.mixmix.global.template.RspTemplate;
+import com.example.mixmix.notification.api.dto.response.NotificationListResDto;
+import com.example.mixmix.notification.application.NotificationService;
+import com.example.mixmix.notification.domain.Type;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notifications")
+public class NotificationController {
+
+    private final NotificationService notificationService;
+
+    @Operation(summary = "SSE 연결 확인", description = "(로그인 시) 알림 수신 준비로 SSE 연결을 설정합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 스트림 연결 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @GetMapping("/stream")
+    public SseEmitter streamNotifications(@CurrentUserEmail String email) {
+        return notificationService.createEmitter(email);
+    }
+
+    @Operation(summary = "알림 목록 조회", description = "알림 정보를 조회합니다 (유형별 알림은 쿼리 파라미터 활용)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 목록 조회 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @GetMapping
+    public RspTemplate<NotificationListResDto> getNotifications( @CurrentUserEmail String email,
+            @RequestParam(value = "type", required = false) Type type) {
+        NotificationListResDto response;
+
+        if (type == null) {
+            response = notificationService.findAllNotifications(email);
+        } else {
+            response = notificationService.findNotificationsByType(email, type);
+        }
+        notificationService.markAllNotificationsRead(email);
+
+        return new RspTemplate<>(HttpStatus.OK, "알림 조회 성공", response);
+    }
+
+    @Operation(summary = "전체 알림 읽음", description = "전체 알림을 읽음으로 표시합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "전체 알림 읽음 처리 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @PatchMapping
+    public RspTemplate<Void> markAllNotificationsAsRead(@CurrentUserEmail String email) {
+        notificationService.markAllNotificationsRead(email);
+        return new RspTemplate<>(HttpStatus.OK, "모든 알림을 읽음으로 처리했습니다.");
+    }
+
+    @Operation(summary = "SSE 연결 해제", description = "(로그아웃 시) SSE 연결을 해제합니다.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "알림 스트림 연결 성공"),
+            @ApiResponse(responseCode = "400", description = "잘못된 요청 값"),
+            @ApiResponse(responseCode = "401", description = "헤더 없음 or 토큰 불일치",
+                    content = @Content(schema = @Schema(example = "INVALID_HEADER or INVALID_TOKEN")))
+    })
+    @DeleteMapping("/disconnect")
+    public RspTemplate<Void> disconnectNotification(@CurrentUserEmail String email) {
+        notificationService.disconnectEmitter(email);
+        return new RspTemplate<>(HttpStatus.OK, "연결 해제 성공");
+    }
+}

--- a/src/main/java/com/example/mixmix/notification/api/dto/response/BasicNotificationResDto.java
+++ b/src/main/java/com/example/mixmix/notification/api/dto/response/BasicNotificationResDto.java
@@ -1,0 +1,25 @@
+package com.example.mixmix.notification.api.dto.response;
+
+import com.example.mixmix.notification.domain.Notification;
+import com.example.mixmix.notification.domain.Type;
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record BasicNotificationResDto(
+        Long id,
+        String message,
+        Type type,
+        Boolean isRead,
+        LocalDateTime createdAt
+) implements NotificationInfoResDto {
+    public static BasicNotificationResDto from(Notification notification) {
+        return BasicNotificationResDto.builder()
+                .id(notification.getId())
+                .message(notification.getMessage())
+                .type(notification.getType())
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .build();
+    }
+}

--- a/src/main/java/com/example/mixmix/notification/api/dto/response/CommentNotificationResDto.java
+++ b/src/main/java/com/example/mixmix/notification/api/dto/response/CommentNotificationResDto.java
@@ -1,0 +1,21 @@
+package com.example.mixmix.notification.api.dto.response;
+
+import com.example.mixmix.feed.domain.Feed;
+import com.example.mixmix.feed.exception.FeedNotFoundException;
+import com.example.mixmix.notification.domain.Notification;
+import com.example.mixmix.notification.domain.Type;
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record CommentNotificationResDto(
+        Long id,
+        String message,
+        Type type,
+        Boolean isRead,
+        LocalDateTime createdAt,
+        Long feedId,
+        String feedImage
+) implements NotificationInfoResDto {
+
+}

--- a/src/main/java/com/example/mixmix/notification/api/dto/response/NotificationInfoResDto.java
+++ b/src/main/java/com/example/mixmix/notification/api/dto/response/NotificationInfoResDto.java
@@ -1,0 +1,4 @@
+package com.example.mixmix.notification.api.dto.response;
+
+public interface NotificationInfoResDto {
+}

--- a/src/main/java/com/example/mixmix/notification/api/dto/response/NotificationListResDto.java
+++ b/src/main/java/com/example/mixmix/notification/api/dto/response/NotificationListResDto.java
@@ -1,0 +1,15 @@
+package com.example.mixmix.notification.api.dto.response;
+
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record NotificationListResDto(
+        List<? extends NotificationInfoResDto> notificationInfoResDtos
+) {
+    public static NotificationListResDto of(List<? extends NotificationInfoResDto> notificationInfoResDtoList) {
+        return NotificationListResDto.builder()
+                .notificationInfoResDtos(notificationInfoResDtoList).build();
+    }
+}

--- a/src/main/java/com/example/mixmix/notification/application/NotificationService.java
+++ b/src/main/java/com/example/mixmix/notification/application/NotificationService.java
@@ -1,0 +1,163 @@
+package com.example.mixmix.notification.application;
+
+import com.example.mixmix.feed.domain.Feed;
+import com.example.mixmix.feed.domain.repository.FeedRepository;
+import com.example.mixmix.feed.exception.FeedNotFoundException;
+import com.example.mixmix.member.domain.Member;
+import com.example.mixmix.member.domain.repository.MemberRepository;
+import com.example.mixmix.member.exception.MemberNotFoundException;
+import com.example.mixmix.notification.api.dto.response.BasicNotificationResDto;
+import com.example.mixmix.notification.api.dto.response.CommentNotificationResDto;
+import com.example.mixmix.notification.api.dto.response.NotificationInfoResDto;
+import com.example.mixmix.notification.api.dto.response.NotificationListResDto;
+import com.example.mixmix.notification.domain.Notification;
+import com.example.mixmix.notification.domain.Type;
+import com.example.mixmix.notification.domain.repository.NotificationRepository;
+import com.example.mixmix.notification.util.NotificationPayload;
+import com.example.mixmix.notification.util.SseEmitterManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+    private static final String STREAK_NOTIFICATION_MESSAGE = "오늘의 도전을 완료하고 새로운 연결을 만들어보세요! \uD83C\uDF0F";
+
+    private final NotificationRepository notificationRepository;
+    private final MemberRepository memberRepository;
+    private final FeedRepository feedRepository;
+    private final SseEmitterManager sseEmitterManager;
+
+    public SseEmitter createEmitter(String email){
+        Member member = findByEmail(email);
+
+        return sseEmitterManager.createEmitter(member.getId());
+    }
+
+    public void disconnectEmitter(String email){
+        Member member = findByEmail(email);
+
+        sseEmitterManager.removeEmitter(member.getId());
+    }
+
+    @Transactional
+    public void sendNotification(Member member, Type type, String message, Long relatedEntityId) {
+        Notification savedNotification = saveNotification(member, type, message, relatedEntityId);
+
+        sseEmitterManager.sendNotification(member.getId(), createPayload(savedNotification));
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationListResDto findAllNotifications(String email) {
+        Member member = findByEmail(email);
+        List<? extends NotificationInfoResDto> notifications = notificationRepository.findAllByReceiver(member)
+                .stream()
+                .map(notification -> {
+                    if(notification.getType() == Type.COMMENT) {
+                        return createComment(notification);
+                    } else {
+                        return BasicNotificationResDto.from(notification);
+                    }
+                })
+                .toList();
+
+        return NotificationListResDto.of(notifications);
+    }
+
+    @Transactional(readOnly = true)
+    public NotificationListResDto findNotificationsByType(String email, Type type) {
+        Member member = findByEmail(email);
+        List<? extends NotificationInfoResDto> notifications;
+
+        if (type == Type.COMMENT) {
+            notifications = findCommentNotifications(member);
+        } else {
+            notifications = findBasicNotifications(member, type);
+        }
+
+        return NotificationListResDto.of(notifications);
+    }
+
+    @Transactional
+    public void markAllNotificationsRead(String email) {
+        Member member = findByEmail(email);
+        List<Notification> notifications = notificationRepository.findAllByReceiver(member);
+
+        notifications.forEach(Notification::markAsRead);
+    }
+
+    public boolean hasUnreadNotifications(String email) {
+        Member member = findByEmail(email);
+
+        return notificationRepository.existsByReceiverAndIsReadFalse(member);
+    }
+
+    @Scheduled(cron = "0 00 18 * * ?")
+    public void sendStreakNotification() {
+        List<Member> members = memberRepository.findAllByIsStreakUpdatedFalse();
+        for (Member member : members) {
+            saveNotification(member, Type.STREAK, STREAK_NOTIFICATION_MESSAGE, member.getId());
+        }
+    }
+
+    private Notification saveNotification(Member member, Type type, String message, Long relatedEntityId) {
+        Notification notification = Notification.builder()
+                .receiver(member)
+                .message(message)
+                .type(type)
+                .isRead(false)
+                .relatedEntityId(relatedEntityId)
+                .build();
+
+        return notificationRepository.save(notification);
+    }
+
+    private Member findByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(MemberNotFoundException::new);
+    }
+
+    private NotificationPayload createPayload(Notification notification) {
+        return new NotificationPayload(notification.getType(), notification.getMessage());
+    }
+
+    private CommentNotificationResDto createComment(Notification notification) {
+        String feedImage = getFeedImage(notification.getRelatedEntityId());
+
+        return CommentNotificationResDto.builder()
+                .id(notification.getId())
+                .message(notification.getMessage())
+                .type(Type.COMMENT)
+                .isRead(notification.getIsRead())
+                .createdAt(notification.getCreatedAt())
+                .feedId(notification.getRelatedEntityId())
+                .feedImage(feedImage).build();
+    }
+
+    private String getFeedImage(Long feedId) {
+        Optional<Feed> feed = feedRepository.findById(feedId);
+        if (feed.isPresent()) {
+            return feed.get().getFeedImage();
+        }
+        throw new FeedNotFoundException();
+    }
+
+    private List<BasicNotificationResDto> findBasicNotifications(Member member, Type type) {
+        return notificationRepository.findAllByReceiverAndType(member, type)
+                .stream()
+                .map(BasicNotificationResDto::from)
+                .toList();
+    }
+
+    private List<CommentNotificationResDto> findCommentNotifications(Member member) {
+        return notificationRepository.findAllByReceiverAndType(member, Type.COMMENT)
+                .stream()
+                .map(this::createComment)
+                .toList();
+    }
+}

--- a/src/main/java/com/example/mixmix/notification/application/NotificationService.java
+++ b/src/main/java/com/example/mixmix/notification/application/NotificationService.java
@@ -101,7 +101,8 @@ public class NotificationService {
     public void sendStreakNotification() {
         List<Member> members = memberRepository.findAllByIsStreakUpdatedFalse();
         for (Member member : members) {
-            saveNotification(member, Type.STREAK, STREAK_NOTIFICATION_MESSAGE, member.getId());
+            Notification savedNotification = saveNotification(member, Type.STREAK, STREAK_NOTIFICATION_MESSAGE, member.getId());
+            sseEmitterManager.sendNotification(member.getId(), createPayload(savedNotification));
         }
     }
 

--- a/src/main/java/com/example/mixmix/notification/domain/Notification.java
+++ b/src/main/java/com/example/mixmix/notification/domain/Notification.java
@@ -1,0 +1,44 @@
+package com.example.mixmix.notification.domain;
+
+import com.example.mixmix.global.entity.BaseEntity;
+import com.example.mixmix.member.domain.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Notification extends BaseEntity {
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member receiver;
+
+    private String message;
+
+    @Enumerated(EnumType.STRING)
+    private Type type;
+
+    @Column(nullable = false)
+    private Boolean isRead;
+
+    private Long relatedEntityId;
+
+    @Builder
+    public Notification(Member receiver, String message, Type type,Boolean isRead, Long relatedEntityId) {
+        this.receiver = receiver;
+        this.message = message;
+        this.type = type;
+        this.isRead = isRead;
+        this.relatedEntityId = relatedEntityId;
+    }
+
+    public void markAsRead() {
+        if (isRead) {
+            return;
+        }
+        isRead = true;
+    }
+}

--- a/src/main/java/com/example/mixmix/notification/domain/Type.java
+++ b/src/main/java/com/example/mixmix/notification/domain/Type.java
@@ -1,0 +1,5 @@
+package com.example.mixmix.notification.domain;
+
+public enum Type {
+    COMMENT, CHAT, STREAK
+}

--- a/src/main/java/com/example/mixmix/notification/domain/repository/NotificationCustomRepository.java
+++ b/src/main/java/com/example/mixmix/notification/domain/repository/NotificationCustomRepository.java
@@ -1,0 +1,4 @@
+package com.example.mixmix.notification.domain.repository;
+
+public interface NotificationCustomRepository {
+}

--- a/src/main/java/com/example/mixmix/notification/domain/repository/NotificationCustomRepositoryImpl.java
+++ b/src/main/java/com/example/mixmix/notification/domain/repository/NotificationCustomRepositoryImpl.java
@@ -1,0 +1,7 @@
+package com.example.mixmix.notification.domain.repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class NotificationCustomRepositoryImpl implements NotificationCustomRepository {
+}

--- a/src/main/java/com/example/mixmix/notification/domain/repository/NotificationRepository.java
+++ b/src/main/java/com/example/mixmix/notification/domain/repository/NotificationRepository.java
@@ -1,0 +1,14 @@
+package com.example.mixmix.notification.domain.repository;
+
+import com.example.mixmix.member.domain.Member;
+import com.example.mixmix.notification.domain.Notification;
+import com.example.mixmix.notification.domain.Type;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationCustomRepository {
+    List<Notification> findAllByReceiver(Member receiver);
+    List<Notification> findAllByReceiverAndType(Member receiver, Type type);
+
+    Boolean existsByReceiverAndIsReadFalse(Member receiver);
+}

--- a/src/main/java/com/example/mixmix/notification/exception/EmitterNotFoundException.java
+++ b/src/main/java/com/example/mixmix/notification/exception/EmitterNotFoundException.java
@@ -1,0 +1,11 @@
+package com.example.mixmix.notification.exception;
+
+import com.example.mixmix.global.error.exception.NotFoundGroupException;
+
+public class EmitterNotFoundException extends NotFoundGroupException {
+    public EmitterNotFoundException(String message) {
+        super(message);
+    }
+
+    public EmitterNotFoundException() { this("해당 회원의 SSE 연결이 없습니다."); }
+}

--- a/src/main/java/com/example/mixmix/notification/util/NotificationPayload.java
+++ b/src/main/java/com/example/mixmix/notification/util/NotificationPayload.java
@@ -1,0 +1,12 @@
+package com.example.mixmix.notification.util;
+
+import com.example.mixmix.notification.domain.Type;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NotificationPayload {
+    private Type type;
+    private String message;
+}

--- a/src/main/java/com/example/mixmix/notification/util/SseEmitterManager.java
+++ b/src/main/java/com/example/mixmix/notification/util/SseEmitterManager.java
@@ -1,0 +1,59 @@
+package com.example.mixmix.notification.util;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class SseEmitterManager {
+
+    private static final String EMITTER_NAME = "notification";
+    private static final String DUMMY_MESSAGE = "연결 성공";
+
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter createEmitter(Long memberId) {
+        if (emitters.get(memberId) != null) {
+            removeEmitter(memberId);
+        }
+
+        SseEmitter emitter = new SseEmitter(Long.MAX_VALUE);
+        emitters.put(memberId, emitter);
+
+        sendNotification(memberId, DUMMY_MESSAGE);
+
+        emitter.onCompletion(() -> emitters.remove(memberId));
+        emitter.onTimeout(() -> emitters.remove(memberId));
+        emitter.onError((e) -> emitters.remove(memberId));
+
+        return emitter;
+    }
+
+    public void sendNotification(Long memberId, Object data) {
+        SseEmitter emitter = emitters.get(memberId);
+
+        if (emitter != null) {
+            try {
+                emitter.send(SseEmitter.event()
+                                .name(EMITTER_NAME)
+                                .data(data));
+            } catch (Exception e) {
+                emitter.completeWithError(e);
+            }
+        }
+    }
+
+    public void removeEmitter(Long memberId) {
+        SseEmitter emitter = emitters.remove(memberId);
+
+        if (emitter != null) {
+            emitter.complete();
+            log.info("해당 회원의 기존 연결이 종료되었습니다: {}", memberId);
+        } else {
+            log.warn("연결되어있는 에미터가 존재하지 않습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## 🚀 About
> feat #14 

## ✅ Key Changes

- CommentService : 다른 사용자의 댓글 추가될 때 알림 전송하는 로직 추가
- MemberController : 마이페이지에서 알림 조회하는 엔드포인트 추가, 안읽은 알림 있는지 함께 전송하는 로직 추가
- MemberRepository :  STREAK 알림을 위한 업데이트 유무 파악하는 JPA 메서드 추가
- MyPageInfoResDto : 안읽은 알림도 같이 전송하도록 함 (unreadNotification)
- MyPageService : 안읽은 알림도 같이 응답으로 전송하도록 수정

- 매일 6시마다 isStreakUpdated 가 false인 사용자에게 알림 전송
- 다른 사용자의 댓글이 추가될 때마다 알림 전송
- Sse 연결 설정 및 알림 전송하는 컨트롤러와 서비스 등 구현


